### PR TITLE
Oprava vytváření transakce, která nemá typ

### DIFF
--- a/src/FioApi/Transaction.php
+++ b/src/FioApi/Transaction.php
@@ -119,7 +119,7 @@ class Transaction
             !empty($data->column6) ? $data->column6->value : null, //SS
             !empty($data->column7) ? $data->column7->value : null, //Uživatelská identifikace
             !empty($data->column16) ? $data->column16->value : null, //Zpráva pro příjemce
-            $data->column8->value, //Typ
+            !empty($data->column8) ? $data->column8->value : '', //Typ
             !empty($data->column9) ? $data->column9->value : null, //Provedl
             !empty($data->column25) ? $data->column25->value : null, //Komentář
             !empty($data->column17) ? $data->column17->value : null, //ID pokynu


### PR DESCRIPTION
Moc nechápu, jak taková transakce může na straně Fio vzniknout, ale [narazili jsme na situaci](https://github.com/skaut/Skautske-hospodareni/issues/1181), kdy platba, kterou vrátí Fio API má `column8` (typ transakce) s hodnotou `null`. Na takové transakci následně díky `strict_types` umře vytváření objektu `Transaction`, protože `$data->column8->value` ~> `null` (+ notice).

Přidal jsem pro ten sloupec stejnou kontrolu jako u ostatních nepovinných sloupců, jedinný rozdíl je, že defaultní hodnota je prázdný string místo `null`, aby nebylo třeba měnit typ, který vrací getter.