### PR TITLE
Updated API url

### DIFF
--- a/src/FioApi/UrlBuilder.php
+++ b/src/FioApi/UrlBuilder.php
@@ -7,7 +7,7 @@ use FioApi\Exceptions\MissingTokenException;
 
 class UrlBuilder
 {
-    const BASE_URL = 'https://www.fio.cz/ib_api/rest/';
+    const BASE_URL = 'https://fioapi.fio.cz/v1/rest/';
 
     /** @var string */
     protected $token;

--- a/tests/FioApi/DownloaderTest.php
+++ b/tests/FioApi/DownloaderTest.php
@@ -90,7 +90,7 @@ class DownloaderTest extends \PHPUnit\Framework\TestCase
         /** @var \GuzzleHttp\Psr7\Request $request */
         $request = $container[0]['request'];
 
-        $this->assertSame('https://www.fio.cz/ib_api/rest/set-last-id/validToken/123456/', (string) $request->getUri());
+        $this->assertSame('https://fioapi.fio.cz/v1/rest/set-last-id/validToken/123456/', (string) $request->getUri());
     }
 
     public function testDownloaderSetCertificatePath()

--- a/tests/FioApi/UrlBuilderTest.php
+++ b/tests/FioApi/UrlBuilderTest.php
@@ -29,7 +29,7 @@ class UrlBuilderTest extends \PHPUnit\Framework\TestCase
     {
         $urlBuilder = new UrlBuilder('token1');
         $this->assertSame(
-            'https://www.fio.cz/ib_api/rest/periods/token1/2015-03-25/2015-03-31/transactions.json',
+            'https://fioapi.fio.cz/v1/rest/periods/token1/2015-03-25/2015-03-31/transactions.json',
             $urlBuilder->buildPeriodsUrl(
                 new \DateTimeImmutable('2015-03-25'),
                 new \DateTimeImmutable('2015-03-31')


### PR DESCRIPTION
Got email today from FIO Banka about API url address change:


> Vážený kliente,
> 
> rádi bychom Vás informovali, že v rámci dalšího zvýšení bezpečnosti našich služeb dochází k přesunu domény Fio API Bankovnictví ze stávající [https](https://www.fio.cz/ib_api/)[://](https://www.fio.cz/ib_api/)[www.](https://www.fio.cz/ib_api/)[fio.](https://www.fio.cz/ib_api/)[cz](https://www.fio.cz/ib_api/)[/](https://www.fio.cz/ib_api/)[ib_api](https://www.fio.cz/ib_api/)[/](https://www.fio.cz/ib_api/) na samostatnou URL [https](https://fioapi.fio.cz/)[://](https://fioapi.fio.cz/)[fioapi.](https://fioapi.fio.cz/)[fio.](https://fioapi.fio.cz/)[cz](https://fioapi.fio.cz/)[/](https://fioapi.fio.cz/).
> 
> Nově je třeba směřovat pokyny zasílané z API Bankovnictví na tuto novou URL. Abychom Vám poskytli dostatek času se této změně přizpůsobit, budou po přechodné období 6 měsíců platné obě výše uvedené adresy.
> 
> V případě dotazů nás prosím kontaktujte prostřednictvím Fio servisu ve svém internetovém nebo mobilním bankovnictví.
>
> [VÍCE INFORMACÍ](https://www.fio.cz/bankovni-sluzby/api-bankovnictvi)