### PR TITLE
PHP 8.4 compatibility: explicit nullable parameter type

### DIFF
--- a/src/FioApi/Downloader.php
+++ b/src/FioApi/Downloader.php
@@ -21,7 +21,7 @@ class Downloader
     /** @var ?ClientInterface */
     protected $client;
 
-    public function __construct(string $token, ClientInterface $client = null)
+    public function __construct(string $token, ?ClientInterface $client = null)
     {
         $this->urlBuilder = new UrlBuilder($token);
         $this->client = $client;


### PR DESCRIPTION
Under PHP 8.4, an implicitly-nullable parameter (a non-nullable type with a `null` default) emits "Implicitly marking parameter as nullable is deprecated". Downloader's constructor declared `ClientInterface $client = null`, so it fires once per class compile on 8.4.

Mark the parameter explicitly nullable. The property is already documented `@var ?ClientInterface`, so this only makes the signature match the intent; behaviour is unchanged.